### PR TITLE
Apply limitations on pistons (config toggleable)

### DIFF
--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/config/Settings.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/config/Settings.java
@@ -32,6 +32,7 @@ public class Settings {
     public final String NOTIFICATION_ACTIONBAR_TOTAL_COLOR;
     public final String NOTIFICATION_ACTIONBAR_SEPARATOR;
     public final int SPIGOT_ENTITY_TRACKER_INTERVAL_TICKS;
+    public final boolean APPLY_PISTON_LIMITS;
     public final List<Class<?>> DISABLED_EVENTS;
     public final boolean WORLDEDIT_INTEGRATION_ENABLED;
     public final WorldEditIntegrationType WORLDEDIT_INTEGRATION_TYPE;
@@ -66,6 +67,7 @@ public class Settings {
         NOTIFICATION_ACTIONBAR_SEPARATOR = parser.getString("settings.notification.actionbar.separator", " ");
 
         SPIGOT_ENTITY_TRACKER_INTERVAL_TICKS = parser.getInt("settings.spigot.entity-tracker-interval-ticks", 10, 1, Integer.MAX_VALUE);
+        APPLY_PISTON_LIMITS = parser.getBoolean("settings.apply-piston-limits", true);
 
         DISABLED_EVENTS = new ArrayList<>();
         Map<String, Class<?>> events = plugin.getAllowedDisableEvents();

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/utils/BlockUtils.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/utils/BlockUtils.java
@@ -64,4 +64,11 @@ public class BlockUtils {
                 ClassObject.of(int.class, z)
         );
     }
+
+    /**
+     * Checks whether two blocks are within the same chunk.
+     */
+    public static boolean isSameChunk(Block x, Block y) {
+        return ((x.getX() >> 4) == (y.getX() >> 4)) && (x.getZ() >> 4) == (y.getZ() >> 4);
+    }
 }

--- a/Insights/src/main/java/dev/frankheijden/insights/Insights.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/Insights.java
@@ -33,6 +33,7 @@ import dev.frankheijden.insights.listeners.BlockListener;
 import dev.frankheijden.insights.listeners.ChunkListener;
 import dev.frankheijden.insights.listeners.EntityListener;
 import dev.frankheijden.insights.listeners.PaperEntityListener;
+import dev.frankheijden.insights.listeners.PistonListener;
 import dev.frankheijden.insights.listeners.PlayerListener;
 import dev.frankheijden.insights.listeners.WorldListener;
 import dev.frankheijden.insights.tasks.EntityTrackerTask;
@@ -134,6 +135,10 @@ public class Insights extends InsightsPlugin {
             entityTrackerTask = new EntityTrackerTask(this);
             int interval = settings.SPIGOT_ENTITY_TRACKER_INTERVAL_TICKS;
             Bukkit.getScheduler().runTaskTimer(this, entityTrackerTask, 0, interval);
+        }
+
+        if (settings.APPLY_PISTON_LIMITS) {
+            registerEvents(new PistonListener(this));
         }
 
         for (Class<?> clazz : settings.DISABLED_EVENTS) {

--- a/Insights/src/main/java/dev/frankheijden/insights/listeners/PistonListener.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/listeners/PistonListener.java
@@ -1,0 +1,93 @@
+package dev.frankheijden.insights.listeners;
+
+import dev.frankheijden.insights.api.InsightsPlugin;
+import dev.frankheijden.insights.api.concurrent.storage.ChunkStorage;
+import dev.frankheijden.insights.api.concurrent.storage.DistributionStorage;
+import dev.frankheijden.insights.api.concurrent.storage.WorldStorage;
+import dev.frankheijden.insights.api.config.limits.Limit;
+import dev.frankheijden.insights.api.listeners.InsightsListener;
+import dev.frankheijden.insights.api.utils.BlockUtils;
+import dev.frankheijden.insights.api.utils.ChunkUtils;
+import org.bukkit.Chunk;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.block.BlockPistonEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public class PistonListener extends InsightsListener {
+
+    public PistonListener(InsightsPlugin plugin) {
+        super(plugin);
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onBlockPistonExtend(BlockPistonExtendEvent event) {
+        handlePistonEvent(event, event.getBlocks());
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
+    public void onBlockPistonRetract(BlockPistonRetractEvent event) {
+        handlePistonEvent(event, event.getBlocks());
+    }
+
+    /**
+     * Handles pistons, blocks the event if necessary.
+     * Events are cancelled whenever:
+     *   - The chunk is queued for scanning
+     *   - The chunk hasn't been scanned yet
+     *   - The limit was surpassed (lowest limit)
+     * Events are allowed whenever:
+     *   - Pushes/retractions happen within the same chunk
+     *   - No limit exists for the pushed/retracted material
+     */
+    private void handlePistonEvent(BlockPistonEvent event, List<Block> blocks) {
+        for (Block block : blocks) {
+            Block relative = block.getRelative(event.getDirection());
+            if (handlePistonBlock(block, relative)) {
+                event.setCancelled(true);
+                break;
+            }
+        }
+    }
+
+    private boolean handlePistonBlock(Block from, Block to) {
+        // Always allow piston pushes within same chunk.
+        if (BlockUtils.isSameChunk(from, to)) return false;
+
+        Material material = from.getType();
+        Optional<Limit> limitOptional = plugin.getLimits().getFirstLimit(material, limit -> true);
+
+        // If no limit is present, allow the block to be moved.
+        if (!limitOptional.isPresent()) return false;
+
+        Chunk chunk = to.getChunk();
+        UUID worldUid = chunk.getWorld().getUID();
+        long chunkKey = ChunkUtils.getKey(chunk);
+
+        // If the chunk is already queued, cancel the event and wait for the chunk to complete.
+        if (plugin.getWorldChunkScanTracker().isQueued(worldUid, chunkKey)) return true;
+
+        WorldStorage worldStorage = plugin.getWorldStorage();
+        ChunkStorage chunkStorage = worldStorage.getWorld(worldUid);
+        Optional<DistributionStorage> storageOptional = chunkStorage.get(chunkKey);
+
+        // If the storage is not present, scan it & cancel the event.
+        if (!storageOptional.isPresent()) {
+            plugin.getChunkContainerExecutor().submit(chunk);
+            return true;
+        }
+
+        // Else, the storage is present, and we can apply a limit.
+        DistributionStorage storage = storageOptional.get();
+        Limit limit = limitOptional.get();
+
+        // Cache doesn't need to updated here just yet, needs to be done in MONITOR event phase.
+        return storage.count(limit, material) + 1 > limit.getLimit();
+    }
+}

--- a/Insights/src/main/resources/config.yml
+++ b/Insights/src/main/resources/config.yml
@@ -20,6 +20,7 @@ settings:
       separator: " "
   spigot:
     entity-tracker-interval-ticks: 10
+  apply-piston-limits: true
   disabled-listeners:
     - "BlockFromToEvent"
     - "FluidLevelChangeEvent"


### PR DESCRIPTION
Events are cancelled whenever:
- The chunk is queued for scanning
- The chunk hasn't been scanned yet
- The limit was surpassed (lowest limit)

Events are allowed whenever:
- Pushes/retractions happen within the same chunk
- No limit exists for the pushed/retracted material

Fixes #22