### PR TITLE
Implement /scanregion to scan addon regions

### DIFF
--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/config/Messages.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/config/Messages.java
@@ -46,7 +46,8 @@ public class Messages {
         SCAN_FINISH_HEADER("scan.finish.header"),
         SCAN_FINISH_FORMAT("scan.finish.format"),
         SCAN_FINISH_FOOTER("scan.finish.footer"),
-        SCAN_PROGRESS("scan.progress");
+        SCAN_PROGRESS("scan.progress"),
+        SCANREGION_NO_REGION("scanregion.no-region");
 
         private final String path;
 

--- a/Insights/src/main/java/dev/frankheijden/insights/Insights.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/Insights.java
@@ -29,6 +29,7 @@ import dev.frankheijden.insights.api.utils.IOUtils;
 import dev.frankheijden.insights.api.utils.ReflectionUtils;
 import dev.frankheijden.insights.commands.CommandInsights;
 import dev.frankheijden.insights.commands.CommandScan;
+import dev.frankheijden.insights.commands.CommandScanRegion;
 import dev.frankheijden.insights.commands.CommandScanWorld;
 import dev.frankheijden.insights.commands.brigadier.BrigadierHandler;
 import dev.frankheijden.insights.commands.parser.MaterialArrayArgument;
@@ -292,6 +293,7 @@ public class Insights extends InsightsPlugin {
         annotationParser.parse(new CommandInsights(this));
         annotationParser.parse(new CommandScan(this));
         annotationParser.parse(new CommandScanWorld(this));
+        annotationParser.parse(new CommandScanRegion(this));
     }
 
     @Override

--- a/Insights/src/main/java/dev/frankheijden/insights/commands/CommandScanRegion.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/commands/CommandScanRegion.java
@@ -24,26 +24,19 @@ public class CommandScanRegion extends InsightsCommand {
 
     @CommandMethod("scanregion tile")
     @CommandPermission("insights.scanregion.tile")
-    private void handleTileScan(
-            Player player
-    ) {
+    private void handleTileScan(Player player) {
         handleScan(player, RTileEntityTypes.getTileEntityMaterials(), false);
     }
 
     @CommandMethod("scanregion all")
     @CommandPermission("insights.scanregion.all")
-    private void handleAllScan(
-            Player player
-    ) {
+    private void handleAllScan(Player player) {
         handleScan(player, null, false);
     }
 
     @CommandMethod("scanregion custom <materials>")
     @CommandPermission("insights.scanregion.custom")
-    private void handleCustomScan(
-            Player player,
-            @Argument("materials") Material[] materials
-    ) {
+    private void handleCustomScan(Player player, @Argument("materials") Material[] materials) {
         handleScan(player, new HashSet<>(Arrays.asList(materials)), true);
     }
 

--- a/Insights/src/main/java/dev/frankheijden/insights/commands/CommandScanRegion.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/commands/CommandScanRegion.java
@@ -1,0 +1,64 @@
+package dev.frankheijden.insights.commands;
+
+import cloud.commandframework.annotations.Argument;
+import cloud.commandframework.annotations.CommandMethod;
+import cloud.commandframework.annotations.CommandPermission;
+import dev.frankheijden.insights.api.InsightsPlugin;
+import dev.frankheijden.insights.api.addons.Region;
+import dev.frankheijden.insights.api.commands.InsightsCommand;
+import dev.frankheijden.insights.api.config.Messages;
+import dev.frankheijden.insights.api.reflection.RTileEntityTypes;
+import dev.frankheijden.insights.api.tasks.ScanTask;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public class CommandScanRegion extends InsightsCommand {
+
+    public CommandScanRegion(InsightsPlugin plugin) {
+        super(plugin);
+    }
+
+    @CommandMethod("scanregion tile")
+    @CommandPermission("insights.scanregion.tile")
+    private void handleTileScan(
+            Player player
+    ) {
+        handleScan(player, RTileEntityTypes.getTileEntityMaterials(), false);
+    }
+
+    @CommandMethod("scanregion all")
+    @CommandPermission("insights.scanregion.all")
+    private void handleAllScan(
+            Player player
+    ) {
+        handleScan(player, null, false);
+    }
+
+    @CommandMethod("scanregion custom <materials>")
+    @CommandPermission("insights.scanregion.custom")
+    private void handleCustomScan(
+            Player player,
+            @Argument("materials") Material[] materials
+    ) {
+        handleScan(player, new HashSet<>(Arrays.asList(materials)), true);
+    }
+
+    /**
+     * Checks the player's location for a region and scans it for materials.
+     */
+    public void handleScan(Player player, Set<Material> materials, boolean displayZeros) {
+        Optional<Region> optionalRegion = plugin.getAddonManager().getRegion(player.getLocation());
+        if (!optionalRegion.isPresent()) {
+            plugin.getMessages().getMessage(Messages.Key.SCANREGION_NO_REGION)
+                    .color()
+                    .sendTo(player);
+            return;
+        }
+
+        ScanTask.scanAndDisplay(plugin, player, optionalRegion.get().toChunkParts(), materials, displayZeros);
+    }
+}

--- a/Insights/src/main/resources/messages.yml
+++ b/Insights/src/main/resources/messages.yml
@@ -16,3 +16,5 @@ messages:
         &3 Scanned through a total of &b&l%chunks% &3chunks with a total of &b&l%blocks% &3blocks. Took &b%time%&3!
         &8&m-------------------------------------------------
     progress: "&3Progress: &b%percentage%%"
+  scanregion:
+    no-region: "<prefix>&cThere does not seem to be any region here!"


### PR DESCRIPTION
Allows the scanning of addon regions with easy using the command `/scanregion`