### PR TITLE
Fixed spigot entity tracker, check Entity#isDead instead

### DIFF
--- a/Insights/src/main/java/dev/frankheijden/insights/tasks/EntityTrackerTask.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/tasks/EntityTrackerTask.java
@@ -34,7 +34,7 @@ public class EntityTrackerTask extends InsightsTask {
         trackedEntities.keySet().removeAll(entities.keySet());
 
         for (Entity entity : trackedEntities.values()) {
-            if (entity.isTicking()) {
+            if (entity.isDead()) {
                 Bukkit.getPluginManager().callEvent(new EntityRemoveFromWorldEvent(entity));
             }
         }


### PR DESCRIPTION
Spigot doesn't implement isTicking(), we will use isDead instead as it does a similar job of finding dead removed entities.
Fixes #57 