### PR TITLE
Make ScanTask greedy instead of patiently waiting on previous iteration

### DIFF
--- a/Insights/src/main/java/dev/frankheijden/insights/commands/CommandScan.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/commands/CommandScan.java
@@ -30,7 +30,7 @@ public class CommandScan extends InsightsCommand {
     @CommandPermission("insights.scan.tile")
     private void handleTileScan(
             Player player,
-            @Argument("radius") @Range(min = "0", max = "25") int radius
+            @Argument("radius") @Range(min = "0", max = "50") int radius
     ) {
         handleScan(player, radius, RTileEntityTypes.getTileEntityMaterials(), false);
     }
@@ -39,7 +39,7 @@ public class CommandScan extends InsightsCommand {
     @CommandPermission("insights.scan.all")
     private void handleAllScan(
             Player player,
-            @Argument("radius") @Range(min = "0", max = "25") int radius
+            @Argument("radius") @Range(min = "0", max = "50") int radius
     ) {
         handleScan(player, radius, null, false);
     }
@@ -48,7 +48,7 @@ public class CommandScan extends InsightsCommand {
     @CommandPermission("insights.scan.custom")
     private void handleCustomScan(
             Player player,
-            @Argument("radius") @Range(min = "0", max = "25") int radius,
+            @Argument("radius") @Range(min = "0", max = "50") int radius,
             @Argument("materials") Material[] materials
     ) {
         handleScan(player, radius, new HashSet<>(Arrays.asList(materials)), true);


### PR DESCRIPTION
ScanTask will now take as many chunks as 'chunksPerIteration' allows concurrently, this means ScanTask no longer waits on the previous iteration to finish completely, but instead allow partial scanning of the next iteration already.