### PR TITLE
Don't depend on worlds being available when Insights is loaded.

### DIFF
--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/config/LimitEnvironment.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/config/LimitEnvironment.java
@@ -2,31 +2,30 @@ package dev.frankheijden.insights.api.config;
 
 import dev.frankheijden.insights.api.config.limits.Limit;
 import org.bukkit.entity.Player;
-import java.util.UUID;
 import java.util.function.Predicate;
 
 public class LimitEnvironment implements Predicate<Limit> {
 
     private final Player player;
-    private final UUID worldUid;
+    private final String worldName;
     private final String addon;
 
-    public LimitEnvironment(Player player, UUID worldUid) {
-        this(player, worldUid, null);
+    public LimitEnvironment(Player player, String worldName) {
+        this(player, worldName, null);
     }
 
     /**
      * Constructs a new LimitEnvironment for a given player, in a given world, and given addon.
      */
-    public LimitEnvironment(Player player, UUID worldUid, String addon) {
+    public LimitEnvironment(Player player, String worldName, String addon) {
         this.player = player;
-        this.worldUid = worldUid;
+        this.worldName = worldName;
         this.addon = addon;
     }
 
     @Override
     public boolean test(Limit limit) {
-        return limit.getSettings().appliesToWorld(worldUid)
+        return limit.getSettings().appliesToWorld(worldName)
                 && (addon == null || limit.getSettings().appliesToAddon(addon))
                 && !player.hasPermission(limit.getBypassPermission());
     }

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/config/limits/Limit.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/config/limits/Limit.java
@@ -3,16 +3,11 @@ package dev.frankheijden.insights.api.config.limits;
 import dev.frankheijden.insights.api.config.parser.SensitiveYamlParser;
 import dev.frankheijden.insights.api.config.parser.YamlParseException;
 import dev.frankheijden.insights.api.config.parser.YamlParser;
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import java.io.File;
 import java.io.IOException;
-import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 public abstract class Limit {
 
@@ -46,14 +41,7 @@ public abstract class Limit {
         String bypassPermission = parser.getString("limit.bypass-permission", null, false);
 
         boolean worldWhitelist = parser.getBoolean("limit.settings.enabled-worlds.whitelist", false, false);
-        Set<String> allowedWorlds = Bukkit.getWorlds().stream()
-                .map(World::getName)
-                .collect(Collectors.toSet());
-        Set<UUID> worlds = parser.getSet("limit.settings.enabled-worlds.worlds", allowedWorlds, "world").stream()
-                .map(Bukkit::getWorld)
-                .filter(Objects::nonNull)
-                .map(World::getUID)
-                .collect(Collectors.toSet());
+        Set<String> worlds = parser.getSet("limit.settings.enabled-worlds.worlds");
 
         boolean addonWhitelist = parser.getBoolean("limit.settings.enabled-addons.whitelist", false, false);
         Set<String> addons = parser.getSet("limit.settings.enabled-addons.addons");

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/config/limits/LimitSettings.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/config/limits/LimitSettings.java
@@ -1,11 +1,10 @@
 package dev.frankheijden.insights.api.config.limits;
 
 import java.util.Set;
-import java.util.UUID;
 
 public class LimitSettings {
 
-    private final Set<UUID> worlds;
+    private final Set<String> worlds;
     private final boolean worldWhitelist;
     private final Set<String> addons;
     private final boolean addonWhitelist;
@@ -13,14 +12,14 @@ public class LimitSettings {
     /**
      * Constructs a new LimitSettings object.
      */
-    public LimitSettings(Set<UUID> worlds, boolean worldWhitelist, Set<String> addons, boolean addonWhitelist) {
+    public LimitSettings(Set<String> worlds, boolean worldWhitelist, Set<String> addons, boolean addonWhitelist) {
         this.worlds = worlds;
         this.worldWhitelist = worldWhitelist;
         this.addons = addons;
         this.addonWhitelist = addonWhitelist;
     }
 
-    public Set<UUID> getWorlds() {
+    public Set<String> getWorlds() {
         return worlds;
     }
 
@@ -31,11 +30,11 @@ public class LimitSettings {
     /**
      * Checks whether this limit can be applied on given world.
      */
-    public boolean appliesToWorld(UUID worldUid) {
+    public boolean appliesToWorld(String worldName) {
         if (worldWhitelist) {
-            return worlds.contains(worldUid);
+            return worlds.contains(worldName);
         } else {
-            return !worlds.contains(worldUid);
+            return !worlds.contains(worldName);
         }
     }
 

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/listeners/InsightsListener.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/listeners/InsightsListener.java
@@ -19,6 +19,7 @@ import dev.frankheijden.insights.api.utils.StringUtils;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.EntityType;
@@ -81,7 +82,8 @@ public abstract class InsightsListener extends InsightsBase implements Listener 
     protected boolean handleAddition(Player player, Location location, Object item, int delta, boolean included) {
         Optional<Region> regionOptional = plugin.getAddonManager().getRegion(location);
         Chunk chunk = location.getChunk();
-        UUID worldUid = chunk.getWorld().getUID();
+        World world = location.getWorld();
+        UUID worldUid = world.getUID();
         long chunkKey = ChunkUtils.getKey(chunk);
 
         boolean queued;
@@ -91,11 +93,11 @@ public abstract class InsightsListener extends InsightsBase implements Listener 
             Region region = regionOptional.get();
             queued = plugin.getAddonScanTracker().isQueued(region.getKey());
             area = plugin.getAddonManager().getAddon(region.getAddon()).getAreaName();
-            env = new LimitEnvironment(player, worldUid, region.getAddon());
+            env = new LimitEnvironment(player, world.getName(), region.getAddon());
         } else {
             queued = plugin.getWorldChunkScanTracker().isQueued(worldUid, chunkKey);
             area = "chunk";
-            env = new LimitEnvironment(player, worldUid);
+            env = new LimitEnvironment(player, world.getName());
         }
 
         if (queued) {
@@ -224,7 +226,8 @@ public abstract class InsightsListener extends InsightsBase implements Listener 
     protected void handleRemoval(Player player, Location location, Object item, int delta) {
         Optional<Region> regionOptional = plugin.getAddonManager().getRegion(location);
         Chunk chunk = location.getChunk();
-        UUID worldUid = chunk.getWorld().getUID();
+        World world = location.getWorld();
+        UUID worldUid = world.getUID();
         long chunkKey = ChunkUtils.getKey(chunk);
         UUID uuid = player.getUniqueId();
 
@@ -234,11 +237,11 @@ public abstract class InsightsListener extends InsightsBase implements Listener 
         if (regionOptional.isPresent()) {
             Region region = regionOptional.get();
             queued = plugin.getAddonScanTracker().isQueued(region.getKey());
-            env = new LimitEnvironment(player, worldUid, region.getAddon());
+            env = new LimitEnvironment(player, world.getName(), region.getAddon());
             storageOptional = plugin.getAddonStorage().get(region.getKey());
         } else {
             queued = plugin.getWorldChunkScanTracker().isQueued(worldUid, chunkKey);
-            env = new LimitEnvironment(player, worldUid);
+            env = new LimitEnvironment(player, world.getName());
             storageOptional = plugin.getWorldStorage().getWorld(worldUid).get(chunkKey);
         }
 

--- a/Insights/src/main/java/dev/frankheijden/insights/placeholders/InsightsPlaceholderExpansion.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/placeholders/InsightsPlaceholderExpansion.java
@@ -11,6 +11,7 @@ import dev.frankheijden.insights.api.utils.StringUtils;
 import me.clip.placeholderapi.expansion.PlaceholderExpansion;
 import org.bukkit.Location;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 import java.util.Locale;
@@ -53,8 +54,9 @@ public class InsightsPlaceholderExpansion extends PlaceholderExpansion {
                 if (item == null) return "";
 
                 Location location = player.getLocation();
-                UUID worldUid = location.getWorld().getUID();
-                LimitEnvironment env = new LimitEnvironment(player, worldUid);
+                World world = location.getWorld();
+                UUID worldUid = world.getUID();
+                LimitEnvironment env = new LimitEnvironment(player, world.getName());
                 Optional<Limit> limitOptional = plugin.getLimits().getFirstLimit(item, env);
                 if (!limitOptional.isPresent()) break;
 


### PR DESCRIPTION
Instead, compare worlds by exact name whenever a limit is applied.