### PR TITLE
Fix indirect block breaks

### DIFF
--- a/Insights/src/main/java/dev/frankheijden/insights/listeners/BlockListener.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/listeners/BlockListener.java
@@ -120,6 +120,11 @@ public class BlockListener extends InsightsListener {
 
         // Handle the removal
         handleRemoval(player, location, ScanObject.of(material), 1, false);
+
+        // Reschedule the chunk for scanning
+        // Hacky way of allowing indirect block breaks,
+        // such as redstone wire popping off when the block below it is being broken.
+        plugin.getChunkContainerExecutor().submit(block.getChunk());
     }
 
     @AllowDisabling

--- a/Insights/src/main/java/dev/frankheijden/insights/listeners/PaperBlockListener.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/listeners/PaperBlockListener.java
@@ -1,0 +1,23 @@
+package dev.frankheijden.insights.listeners;
+
+import com.destroystokyo.paper.event.block.BlockDestroyEvent;
+import dev.frankheijden.insights.api.InsightsPlugin;
+import dev.frankheijden.insights.api.annotations.AllowDisabling;
+import dev.frankheijden.insights.api.listeners.InsightsListener;
+import org.bukkit.block.Block;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+
+public class PaperBlockListener extends InsightsListener {
+
+    public PaperBlockListener(InsightsPlugin plugin) {
+        super(plugin);
+    }
+
+    @AllowDisabling
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onBlockDestroy(BlockDestroyEvent event) {
+        Block block = event.getBlock();
+        handleModification(block.getLocation(), block.getType(), event.getNewState().getMaterial(), 1);
+    }
+}


### PR DESCRIPTION
The fix for this is by scanning the chunk after the block break happened. Luckily, scanning already loaded chunks can be done fully asynchronous, which minimizes the impact of the load on the main thread for this change.

The reason this approach was chosen, is that checking for updates in another way (ie through BlockPhysicsEvent) is just extremely not performant. Paper has a method BlockDestroyEvent, but unfortunately this event does not cover some cases where the block that's being broken in the world does not make a sound (e.g. REDSTONE_WIRE).