### PR TITLE
Handle TNT Prime event on paper servers

### DIFF
--- a/Insights/src/main/java/dev/frankheijden/insights/listeners/PaperEntityListener.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/listeners/PaperEntityListener.java
@@ -1,6 +1,9 @@
 package dev.frankheijden.insights.listeners;
 
+import com.destroystokyo.paper.event.block.TNTPrimeEvent;
 import dev.frankheijden.insights.api.InsightsPlugin;
+import dev.frankheijden.insights.api.objects.wrappers.ScanObject;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 
@@ -16,5 +19,22 @@ public class PaperEntityListener extends EntityListener {
     @EventHandler(priority = EventPriority.MONITOR)
     public void onEntityRemove(com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent event) {
         handleEntityRemoveFromWorld(event.getEntity());
+    }
+
+    /**
+     * Handles the TNTPrimeEvent for ignited TNT blocks.
+     */
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onTNTPrime(TNTPrimeEvent event) {
+        var primerEntity = event.getPrimerEntity();
+        var block = event.getBlock();
+
+        if (primerEntity instanceof Player) {
+            var player = (Player) primerEntity;
+
+            handleRemoval(player, block.getLocation(), ScanObject.of(block.getType()), 1, false);
+        } else {
+            handleModification(block, -1);
+        }
     }
 }


### PR DESCRIPTION
This feature will be paper only, since it provides the [TNTPrimeEvent](https://papermc.io/javadocs/paper/1.17/com/destroystokyo/paper/event/block/TNTPrimeEvent.html) API. Some considerations why other events are suboptimal within the spigot api:
- EntityExplodeEvent cannot be used since the TNT entity might be exploded in another chunk than the TNT block (we can't assume entity location == block location, because e.g. a TNT cannon)
- EntitySpawnEvent also fires for dispensers, and unfortunately the SpawnReason for the TNT entity is the same as when it were primed from a TNT block