### PR TITLE
Improve performance of chunk scanning by reading data directly

### DIFF
--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/concurrent/containers/ChunkContainer.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/concurrent/containers/ChunkContainer.java
@@ -4,74 +4,68 @@ import dev.frankheijden.insights.api.concurrent.ScanOptions;
 import dev.frankheijden.insights.api.concurrent.storage.DistributionStorage;
 import dev.frankheijden.insights.api.objects.chunk.ChunkCuboid;
 import dev.frankheijden.insights.api.objects.chunk.ChunkVector;
-import dev.frankheijden.insights.api.reflection.RChunk;
 import dev.frankheijden.insights.api.reflection.RChunkSection;
-import dev.frankheijden.insights.api.reflection.RCraftChunk;
+import dev.frankheijden.insights.api.reflection.RCraftMagicNumbers;
+import dev.frankheijden.insights.api.reflection.RCraftWorld;
 import dev.frankheijden.insights.api.reflection.RPersistentEntitySectionManager;
-import dev.frankheijden.insights.api.reflection.RWorldServer;
 import dev.frankheijden.insights.api.utils.ChunkUtils;
+import net.minecraft.server.level.WorldServer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkCoordIntPair;
+import net.minecraft.world.level.chunk.ChunkSection;
 import net.minecraft.world.level.entity.EntitySection;
 import net.minecraft.world.level.entity.PersistentEntitySectionManager;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.entity.EntityType;
 import org.bukkit.util.NumberConversions;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.Consumer;
 
-public class ChunkContainer implements SupplierContainer<DistributionStorage> {
+public abstract class ChunkContainer implements SupplierContainer<DistributionStorage> {
 
-    private final org.bukkit.Chunk bukkitChunk;
-    private final UUID worldUid;
-    private final ChunkCuboid cuboid;
-    private final ScanOptions options;
-    private final Map<Material, Integer> materialMap;
-    private final Map<EntityType, Integer> entityMap;
-
-    public ChunkContainer(org.bukkit.Chunk chunk, UUID worldUid) {
-        this(chunk, worldUid, ScanOptions.all());
-    }
-
-    public ChunkContainer(org.bukkit.Chunk chunk, UUID worldUid, ScanOptions options) {
-        this(chunk, worldUid, ChunkCuboid.MAX, options);
-    }
+    protected final World world;
+    protected final int chunkX;
+    protected final int chunkZ;
+    protected final ChunkCuboid cuboid;
+    protected final ScanOptions options;
+    protected final Map<Material, Integer> materialMap;
+    protected final Map<EntityType, Integer> entityMap;
 
     /**
      * Constructs a new ChunkSnapshotContainer, with the area to be scanned as a cuboid.
      */
-    @SuppressWarnings("LineLength")
-    public ChunkContainer(org.bukkit.Chunk bukkitChunk, UUID worldUid, ChunkCuboid cuboid, ScanOptions options) {
-        this.bukkitChunk = bukkitChunk;
-        this.worldUid = worldUid;
+    protected ChunkContainer(World world, int chunkX, int chunkZ, ChunkCuboid cuboid, ScanOptions options) {
+        this.world = world;
+        this.chunkX = chunkX;
+        this.chunkZ = chunkZ;
         this.cuboid = cuboid;
         this.options = options;
         this.materialMap = new EnumMap<>(Material.class);
         this.entityMap = new EnumMap<>(EntityType.class);
     }
 
-    public UUID getWorldUid() {
-        return worldUid;
+    public World getWorld() {
+        return world;
     }
 
     public long getChunkKey() {
-        return ChunkUtils.getKey(getX(), getZ());
+        return ChunkUtils.getKey(chunkX, chunkZ);
     }
 
     public int getX() {
-        return bukkitChunk.getX();
+        return chunkX;
     }
 
     public int getZ() {
-        return bukkitChunk.getZ();
+        return chunkZ;
     }
+
+    public abstract ChunkSection[] getChunkSections() throws Throwable;
 
     @Override
     public DistributionStorage get() {
-        Object chunk = RCraftChunk.getReflection().invoke(bukkitChunk, "getHandle");
-
         ChunkVector min = cuboid.getMin();
         ChunkVector max = cuboid.getMax();
         int minX = min.getX();
@@ -81,22 +75,36 @@ public class ChunkContainer implements SupplierContainer<DistributionStorage> {
         int blockMinY = min.getY();
         int blockMaxY = max.getY();
 
-        if (options.materials()) {
-            Object[] sections = RChunk.getReflection().invoke(chunk, "getSections");
+        try {
+            WorldServer serverLevel = RCraftWorld.getServerLevel(world);
 
-            int minSectionY = blockMinY >> 4;
-            int maxSectionY = blockMaxY >> 4;
+            if (options.materials()) {
+                ChunkSection[] chunkSections = getChunkSections();
 
-            try {
+                int minSectionY = blockMinY >> 4;
+                int maxSectionY = blockMaxY >> 4;
+
                 for (int sectionY = minSectionY; sectionY <= maxSectionY; sectionY++) {
                     int minY = sectionY == minSectionY ? blockMinY & 15 : 0;
                     int maxY = sectionY == maxSectionY ? blockMaxY & 15 : 15;
 
-                    Object section = sections[sectionY];
-                    if (RChunkSection.isEmpty(section)) {
+                    ChunkSection section = chunkSections[sectionY];
+                    if (section == null) {
+                        // Section is empty, count everything as air
                         int count = (maxX - minX + 1) * (maxY - minY + 1) * (maxZ - minZ + 1);
                         materialMap.merge(Material.AIR, count, Integer::sum);
+                    } else if (minX == 0 && maxX == 15 && minY == 0 && maxY == 15 && minZ == 0 && maxZ == 15) {
+                        // Section can be counted as a whole
+                        section.getBlocks().a((state, count) -> {
+                            try {
+                                var material = RCraftMagicNumbers.getMaterial(state.getBlock());
+                                materialMap.merge(material, count, Integer::sum);
+                            } catch (Throwable th) {
+                                th.printStackTrace();
+                            }
+                        });
                     } else {
+                        // Section must be scanned block by block
                         for (int x = minX; x <= maxX; x++) {
                             for (int y = minY; y <= maxY; y++) {
                                 for (int z = minZ; z <= maxZ; z++) {
@@ -106,16 +114,10 @@ public class ChunkContainer implements SupplierContainer<DistributionStorage> {
                         }
                     }
                 }
-            } catch (Throwable th) {
-                //
             }
-        }
 
-        if (options.entities()) {
-            try {
-                PersistentEntitySectionManager<Entity> entityManager = RWorldServer.getPersistentEntityManager(
-                        bukkitChunk.getWorld()
-                );
+            if (options.entities()) {
+                PersistentEntitySectionManager<Entity> entityManager = serverLevel.G;
 
                 Consumer<Entity> entityConsumer = entity -> {
                     int x = NumberConversions.floor(entity.locX()) & 15;
@@ -131,11 +133,11 @@ public class ChunkContainer implements SupplierContainer<DistributionStorage> {
                             .b(getChunkKey()).flatMap(EntitySection::b).forEach(entityConsumer);
                 } else {
                     RPersistentEntitySectionManager.getPermanentStorage(entityManager)
-                            .a(new ChunkCoordIntPair(getX(), getZ())).join().b().forEach(entityConsumer);
+                            .a(new ChunkCoordIntPair(chunkX, chunkZ)).join().b().forEach(entityConsumer);
                 }
-            } catch (Throwable th) {
-                //
             }
+        } catch (Throwable th) {
+            th.printStackTrace();
         }
 
         return DistributionStorage.of(materialMap, entityMap);

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/concurrent/containers/LoadedChunkContainer.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/concurrent/containers/LoadedChunkContainer.java
@@ -1,0 +1,28 @@
+package dev.frankheijden.insights.api.concurrent.containers;
+
+import dev.frankheijden.insights.api.concurrent.ScanOptions;
+import dev.frankheijden.insights.api.objects.chunk.ChunkCuboid;
+import dev.frankheijden.insights.api.reflection.RChunk;
+import dev.frankheijden.insights.api.reflection.RCraftChunk;
+import net.minecraft.world.level.chunk.ChunkSection;
+import org.bukkit.Chunk;
+
+public class LoadedChunkContainer extends ChunkContainer {
+
+    private final Chunk chunk;
+
+    /**
+     * Constructs a new LoadedChunkContainer, for scanning of a loaded chunk.
+     */
+    public LoadedChunkContainer(Chunk chunk, ChunkCuboid cuboid, ScanOptions options) {
+        super(chunk.getWorld(), chunk.getX(), chunk.getZ(), cuboid, options);
+
+        this.chunk = chunk;
+    }
+
+    @Override
+    public ChunkSection[] getChunkSections() {
+        var nmsChunk = RCraftChunk.getReflection().invoke(chunk, "getHandle");
+        return RChunk.getReflection().invoke(nmsChunk, "getSections");
+    }
+}

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/concurrent/containers/UnloadedChunkContainer.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/concurrent/containers/UnloadedChunkContainer.java
@@ -1,0 +1,50 @@
+package dev.frankheijden.insights.api.concurrent.containers;
+
+import dev.frankheijden.insights.api.concurrent.ScanOptions;
+import dev.frankheijden.insights.api.objects.chunk.ChunkCuboid;
+import dev.frankheijden.insights.api.reflection.RCraftWorld;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraft.server.level.WorldServer;
+import net.minecraft.world.level.ChunkCoordIntPair;
+import net.minecraft.world.level.chunk.ChunkSection;
+import org.bukkit.World;
+
+public class UnloadedChunkContainer extends ChunkContainer {
+
+    /**
+     * Constructs a new UnloadedChunkContainer, for scanning of an unloaded chunk.
+     */
+    public UnloadedChunkContainer(World world, int chunkX, int chunkZ, ChunkCuboid cuboid, ScanOptions options) {
+        super(world, chunkX, chunkZ, cuboid, options);
+    }
+
+    @Override
+    public ChunkSection[] getChunkSections() throws Throwable {
+        WorldServer serverLevel = RCraftWorld.getServerLevel(world);
+
+        NBTTagCompound nbt = serverLevel.getChunkProvider().a.read(new ChunkCoordIntPair(chunkX, chunkZ));
+        NBTTagCompound levelNbt = nbt.getCompound("Level");
+        NBTTagList sectionsNbtList = levelNbt.getList("Sections", 10);
+
+        int sectionsCount = serverLevel.getSectionsCount();
+        var chunkSections = new ChunkSection[sectionsCount];
+
+        for (var i = 0; i < sectionsNbtList.size(); i++) {
+            NBTTagCompound sectionNbt = sectionsNbtList.getCompound(i);
+            var chunkSectionPart = sectionNbt.getByte("Y");
+
+            if (sectionNbt.hasKeyOfType("Palette", 9) && sectionNbt.hasKeyOfType("BlockStates", 12)) {
+                var chunkSection = new ChunkSection(chunkSectionPart);
+
+                chunkSection.getBlocks().a(
+                        sectionNbt.getList("Palette", 10),
+                        sectionNbt.getLongArray("BlockStates")
+                );
+                chunkSections[serverLevel.getSectionIndexFromSectionY(chunkSectionPart)] = chunkSection;
+            }
+        }
+
+        return chunkSections;
+    }
+}

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/reflection/RCraftWorld.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/reflection/RCraftWorld.java
@@ -4,6 +4,7 @@ import dev.frankheijden.minecraftreflection.MinecraftReflection;
 import dev.frankheijden.minecraftreflection.Reflection;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import net.minecraft.server.level.WorldServer;
 import org.bukkit.World;
 
 public class RCraftWorld {
@@ -25,7 +26,7 @@ public class RCraftWorld {
 
     private RCraftWorld() {}
 
-    public static Object getServerLevel(World world) throws Throwable {
-        return worldMethodHandle.invoke(world);
+    public static WorldServer getServerLevel(World world) throws Throwable {
+        return (WorldServer) worldMethodHandle.invoke(world);
     }
 }


### PR DESCRIPTION
Chunk data is now read directly if a chunk is unloaded, this has the massive benefit of not wasting memory/server resources for chunks that will just be loaded for a few milliseconds.