### PR TITLE
1.21.3 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 # Changelog
-- 1.21.3 Support by @Jsinco
+- 1.21.3 Support by @Jsinco (removes support for <= 1.21.2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 # Changelog
-- Fix /scanworld command parser, thx @ben9964 <3
+- 1.21.3 Support by @Jsinco

--- a/Insights-NMS/Current/build.gradle.kts
+++ b/Insights-NMS/Current/build.gradle.kts
@@ -1,3 +1,3 @@
 dependencies {
-    paperweight.paperDevBundle("1.21-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("1.21.3-R0.1-SNAPSHOT")
 }

--- a/Insights-NMS/Current/src/main/java/dev/frankheijden/insights/nms/impl/InsightsNMSImpl.java
+++ b/Insights-NMS/Current/src/main/java/dev/frankheijden/insights/nms/impl/InsightsNMSImpl.java
@@ -1,7 +1,7 @@
 package dev.frankheijden.insights.nms.impl;
 
-import ca.spottedleaf.concurrentutil.executor.standard.PrioritisedExecutor;
-import ca.spottedleaf.moonrise.patches.chunk_system.io.RegionFileIOThread;
+import ca.spottedleaf.concurrentutil.util.Priority;
+import ca.spottedleaf.moonrise.patches.chunk_system.io.MoonriseRegionFileIO;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import dev.frankheijden.insights.nms.core.ChunkEntity;
@@ -20,7 +20,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.chunk.PalettedContainer;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
-import net.minecraft.world.level.chunk.storage.ChunkSerializer;
+import net.minecraft.world.level.chunk.storage.SerializableChunkData;
 import org.bukkit.Chunk;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -67,7 +67,7 @@ public class InsightsNMSImpl extends InsightsNMS {
 
             PalettedContainer<BlockState> blockStateContainer;
             if (sectionTag.contains("block_states", Tag.TAG_COMPOUND)) {
-                Codec<PalettedContainer<BlockState>> blockStateCodec = ChunkSerializer.BLOCK_STATE_CODEC;
+                Codec<PalettedContainer<BlockState>> blockStateCodec = SerializableChunkData.BLOCK_STATE_CODEC;
                 dataResult = blockStateCodec.parse(
                         NbtOps.INSTANCE,
                         sectionTag.getCompound("block_states")
@@ -125,12 +125,12 @@ public class InsightsNMSImpl extends InsightsNMS {
             Consumer<ChunkEntity> entityConsumer
     ) throws IOException {
         var serverLevel = ((CraftWorld) world).getHandle();
-        CompoundTag tag = RegionFileIOThread.loadData(
+        CompoundTag tag = MoonriseRegionFileIO.loadData(
                 serverLevel,
                 chunkX,
                 chunkZ,
-                RegionFileIOThread.RegionFileType.ENTITY_DATA,
-                PrioritisedExecutor.Priority.BLOCKING
+                MoonriseRegionFileIO.RegionFileType.ENTITY_DATA,
+                Priority.BLOCKING
         );
         if (tag == null) return;
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,12 +12,12 @@ plugins {
 val name = "Insights"
 group = "dev.frankheijden.insights"
 val dependencyDir = "$group.dependencies"
-version = "6.19.2"
+version = "6.19.3"
 
 subprojects {
     apply(plugin = "java")
     apply(plugin = "checkstyle")
-    apply(plugin = "com.github.johnrengelman.shadow")
+    apply(plugin = "com.gradleup.shadow")
 
     version = rootProject.version
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,18 +157,6 @@ tasks.register<Copy>("copyJars") {
 }
 
 buildscript {
-    // tmp workaround for the shadow plugin + Java 21:
-    // https://github.com/johnrengelman/shadow/pull/876#issuecomment-1942380071
-    // -> No longer needed, gradleup
-//    configurations {
-//        classpath {
-//            resolutionStrategy {
-//                force("org.ow2.asm:asm:9.6")
-//                force("org.ow2.asm:asm-commons:9.6")
-//            }
-//        }
-//    }
-
     dependencies {
         classpath("io.github.z4kn4fein:semver:2.0.0")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,14 +159,15 @@ tasks.register<Copy>("copyJars") {
 buildscript {
     // tmp workaround for the shadow plugin + Java 21:
     // https://github.com/johnrengelman/shadow/pull/876#issuecomment-1942380071
-    configurations {
-        classpath {
-            resolutionStrategy {
-                force("org.ow2.asm:asm:9.6")
-                force("org.ow2.asm:asm-commons:9.6")
-            }
-        }
-    }
+    // -> No longer needed, gradleup
+//    configurations {
+//        classpath {
+//            resolutionStrategy {
+//                force("org.ow2.asm:asm:9.6")
+//                force("org.ow2.asm:asm-commons:9.6")
+//            }
+//        }
+//    }
 
     dependencies {
         classpath("io.github.z4kn4fein:semver:2.0.0")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 semver = "0.10.2"
-minecraft = "1.21-R0.1-SNAPSHOT"
+minecraft = "1.21.3-R0.1-SNAPSHOT"
 paperLib = "1.0.8"
 bStats = "3.0.0"
 adventure = "4.17.0"
@@ -10,14 +10,14 @@ assertj = "3.23.1"
 mockito = "4.11.0"
 jupiter = "5.9.1"
 brigadier = "1.0.18"
-placeholderapi = "2.11.4"
+placeholderapi = "2.11.6"
 commodore = "2.2"
 cloudPaper = "2.0.0-beta.9"
 cloud = "2.0.0-rc.2"
 
 # plugins
-shadow = "8.1.1"
-userdev = "1.7.1"
+shadow = "9.0.0-beta2"
+userdev = "1.7.5"
 pluginYml = "0.6.0"
 
 [libraries]
@@ -40,6 +40,6 @@ cloudPaper = { group = "org.incendo", name = "cloud-paper", version.ref = "cloud
 cloudAnnotations = { group = "org.incendo", name = "cloud-annotations", version.ref = "cloud" }
 
 [plugins]
-shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 userdev = { id = "io.papermc.paperweight.userdev", version.ref = "userdev" }
 pluginYml = { id = "net.minecrell.plugin-yml.bukkit", version.ref = "pluginYml" }


### PR DESCRIPTION
- Updated Paper API/Userdev to 1.21.3
- Updated PAPI to 2.11.6
- Swapped from `com.github.johnrengelman.shadow` to `com.gradleup.shadow` (new maintainers)
- Changed NMS impl to renamed/moved classes in 1.21.3

That's all I think.

Closes #222 