### PR TITLE
1.21.4 support (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 # Changelog
-- 1.21.3 Support by @Jsinco (removes support for <= 1.21.2)
+- 1.21.4 Support by @funniray (removes support for <= 1.21.3)

--- a/Insights-NMS/Current/build.gradle.kts
+++ b/Insights-NMS/Current/build.gradle.kts
@@ -1,3 +1,3 @@
 dependencies {
-    paperweight.paperDevBundle("1.21.3-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("1.21.4-R0.1-SNAPSHOT")
 }

--- a/Insights/src/main/java/dev/frankheijden/insights/commands/util/CommandSenderMapper.java
+++ b/Insights/src/main/java/dev/frankheijden/insights/commands/util/CommandSenderMapper.java
@@ -18,8 +18,12 @@ public class CommandSenderMapper implements SenderMapper<CommandSourceStack, Com
     @Override
     public CommandSourceStack reverse(CommandSender sender) {
         return new CommandSourceStack() {
+            private Location location = null;
+            private Entity entity = null;
+
             @Override
             public @NotNull Location getLocation() {
+                if (location != null) return location;
                 if (sender instanceof Entity entity) {
                     return entity.getLocation();
                 }
@@ -35,7 +39,21 @@ public class CommandSenderMapper implements SenderMapper<CommandSourceStack, Com
 
             @Override
             public @Nullable Entity getExecutor() {
+                if (entity != null) return entity;
                 return sender instanceof Entity entity ? entity : null;
+            }
+
+            // Needs testing
+            @Override
+            public CommandSourceStack withLocation(Location location) {
+                this.location = location;
+                return this;
+            }
+
+            @Override
+            public CommandSourceStack withExecutor(Entity entity) {
+                this.entity = entity;
+                return this;
             }
         };
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ subprojects {
         maven("https://repo.codemc.io/repository/maven-public")
         maven("https://oss.sonatype.org/content/repositories/snapshots/")
         maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-        maven("https://papermc.io/repo/repository/maven-public/")
+        maven("https://repo.papermc.io/repository/maven-public/")
         maven("https://libraries.minecraft.net")
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 semver = "0.10.2"
-minecraft = "1.21.3-R0.1-SNAPSHOT"
+minecraft = "1.21.4-R0.1-SNAPSHOT"
 paperLib = "1.0.8"
 bStats = "3.0.0"
 adventure = "4.17.0"
@@ -17,7 +17,7 @@ cloud = "2.0.0-rc.2"
 
 # plugins
 shadow = "9.0.0-beta2"
-userdev = "1.7.5"
+userdev = "2.0.0-beta.13"
 pluginYml = "0.6.0"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Adds 1.21.4 support
- paperweight userdev updated
- gradle updated, as paperweight userdev requires at minimum gradle 8.12

Unsure if I handled CommandSourceStack properly, but it appears to work fine

Fixes #226 