### PR TITLE
Replace ChunkMap with Moonrise API for better version compatibility

### DIFF
--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/concurrent/containers/UnloadedChunkContainer.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/concurrent/containers/UnloadedChunkContainer.java
@@ -28,7 +28,7 @@ public class UnloadedChunkContainer extends ChunkContainer {
     }
 
     @Override
-    public void getChunkSections(Consumer<@Nullable ChunkSection> sectionConsumer) {
+    public void getChunkSections(Consumer<@Nullable ChunkSection> sectionConsumer) throws IOException {
         nms.getUnloadedChunkSections(world, chunkX, chunkZ, sectionConsumer);
     }
 

--- a/Insights-NMS/Core/src/main/java/dev/frankheijden/insights/nms/core/InsightsNMS.java
+++ b/Insights-NMS/Core/src/main/java/dev/frankheijden/insights/nms/core/InsightsNMS.java
@@ -34,7 +34,7 @@ public abstract class InsightsNMS {
             int chunkX,
             int chunkZ,
             Consumer<ChunkSection> sectionConsumer
-    );
+    ) throws IOException;
 
     public abstract void getLoadedChunkEntities(Chunk chunk, Consumer<ChunkEntity> entityConsumer);
 


### PR DESCRIPTION
- Fix NoSuchFieldError with ServerChunkCache.chunkMap
- Ensure compatibility across all 1.21.* versions
- Support both Paper and Purpur server implementations