### PR TITLE
Added support for version 26.2 and dropped support for version 1.21.10.

### DIFF
--- a/Insights-NMS/Current/build.gradle.kts
+++ b/Insights-NMS/Current/build.gradle.kts
@@ -1,3 +1,3 @@
 dependencies {
-    paperweight.paperDevBundle("26.1.2.build.+")
+    paperweight.paperDevBundle("26.2.build.+")
 }

--- a/Insights-NMS/Current/src/main/java/dev/frankheijden/insights/nms/impl/InsightsNMSImpl.java
+++ b/Insights-NMS/Current/src/main/java/dev/frankheijden/insights/nms/impl/InsightsNMSImpl.java
@@ -7,10 +7,12 @@ import com.mojang.serialization.DataResult;
 import dev.frankheijden.insights.nms.core.ChunkEntity;
 import dev.frankheijden.insights.nms.core.ChunkSection;
 import dev.frankheijden.insights.nms.core.InsightsNMS;
+import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.nbt.NbtOps;
 import net.minecraft.nbt.Tag;
+import net.minecraft.resources.Identifier;
 import net.minecraft.util.Mth;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
@@ -165,7 +167,7 @@ public class InsightsNMSImpl extends InsightsNMS {
     }
 
     private void readChunkEntities(CompoundTag nbt, Consumer<ChunkEntity> entityConsumer) {
-        var typeOptional = net.minecraft.world.entity.EntityType.byString(nbt.getString("id").orElseThrow());
+        var typeOptional = BuiltInRegistries.ENTITY_TYPE.getOptional(Identifier.tryParse(nbt.getString("id").orElseThrow()));
         if (typeOptional.isPresent()) {
             String entityTypeName = net.minecraft.world.entity.EntityType.getKey(typeOptional.get()).getPath();
             ListTag posList = nbt.getList("Pos").orElseThrow();

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 group = "dev.frankheijden.insights"
 version = "6.21.2"
 val dependencyDir = "$group.dependencies"
-val targetMinecraftVersions = listOf("26.1.2", "1.21.11", "1.21.10")
+val targetMinecraftVersions = listOf("26.2", "26.1.2", "1.21.11")
 
 subprojects {
     apply(plugin = "java")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 semver = "0.10.2"
-minecraft = "26.1.2.build.+"
+minecraft = "26.2.build.+"
 bStats = "3.0.0"
 adventure = "4.17.0"
 adventurePlatformBukkit = "4.4.1"


### PR DESCRIPTION
Support for version 1.21.10 was removed following the renaming of the ResourceKey class to Identifier and the removal of EntityType#byString.