### PR TITLE
Fix Adventure 26.2

### DIFF
--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/config/Messages.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/config/Messages.java
@@ -7,7 +7,6 @@ import dev.frankheijden.insights.api.objects.chunk.ChunkLocation;
 import dev.frankheijden.insights.api.objects.wrappers.ScanObject;
 import dev.frankheijden.insights.api.utils.StringUtils;
 import net.kyori.adventure.audience.Audience;
-import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.event.ClickEvent;
 import net.kyori.adventure.text.event.HoverEvent;
@@ -33,23 +32,17 @@ import java.util.function.ToLongFunction;
 public class Messages {
 
     private final InsightsPlugin plugin;
-    private final BukkitAudiences audiences;
     private final YamlParser parser;
     private final MiniMessage miniMessage;
     private final Map<Key, String> messageCache;
     private final TagResolver prefixResolver;
 
-    protected Messages(InsightsPlugin plugin, BukkitAudiences audiences, YamlParser parser) {
+    protected Messages(InsightsPlugin plugin, YamlParser parser) {
         this.plugin = plugin;
-        this.audiences = audiences;
         this.parser = parser;
         this.miniMessage = MiniMessage.miniMessage();
         this.messageCache = new EnumMap<>(Key.class);
         this.prefixResolver = tagOf("prefix", miniMessage.deserialize(getRawMessage(Key.PREFIX)));
-    }
-
-    public BukkitAudiences getAudiences() {
-        return audiences;
     }
 
     public Message getMessage(Key messageKey) {
@@ -122,11 +115,10 @@ public class Messages {
 
     public static Messages load(
             InsightsPlugin plugin,
-            BukkitAudiences audiences,
             File file,
             InputStream defaultSettings
     ) throws IOException {
-        return new Messages(plugin, audiences, PassiveYamlParser.load(file, defaultSettings));
+        return new Messages(plugin, PassiveYamlParser.load(file, defaultSettings));
     }
 
     public static TagResolver tagOf(String name, String content) {
@@ -272,7 +264,14 @@ public class Messages {
          * Sends the message to given receiver, using the message type defined.
          */
         public void sendTo(CommandSender sender) {
-            sendTo(audiences.sender(sender));
+            if (content != null && !content.isEmpty()) {
+                var component = miniMessage.deserialize(content, resolver);
+                if (type == Type.ACTIONBAR) {
+                    sender.sendActionBar(component);
+                } else {
+                    sender.sendMessage(component);
+                }
+            }
         }
 
         /**
@@ -380,12 +379,10 @@ public class Messages {
                 components.add(elementFormatFunction.apply(elements[i]));
             }
 
-            var audience = audiences.sender(sender);
-
             header.sendTo(sender);
-            components.forEach(audience::sendMessage);
+            components.forEach(sender::sendMessage);
             footer.sendTo(sender);
-            audience.sendMessage(createFooter(page));
+            sender.sendMessage(createFooter(page));
         }
     }
 }

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/config/Messages.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/config/Messages.java
@@ -86,7 +86,7 @@ public class Messages {
 
             if (obj instanceof Material material) {
                 var key = material.getKey();
-                if (material.isItem()) {
+                if (material.isItem() && !material.isAir()) {
                     return component.hoverEvent(HoverEvent.showItem(
                             net.kyori.adventure.key.Key.key(key.getNamespace(), key.getKey()),
                             1

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/config/notifications/ActionBarNotification.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/config/notifications/ActionBarNotification.java
@@ -30,9 +30,8 @@ public class ActionBarNotification implements Notification {
         return new SendableNotification(content.resetTemplates()) {
             @Override
             public void send() {
-                var audiences = plugin.getMessages().getAudiences();
                 content.toComponent().ifPresent(component -> receivers.values()
-                        .forEach(player -> audiences.player(player).sendActionBar(component)));
+                        .forEach(player -> player.sendActionBar(component)));
             }
         };
     }

--- a/Insights-API/src/main/java/dev/frankheijden/insights/api/config/notifications/BossBarNotification.java
+++ b/Insights-API/src/main/java/dev/frankheijden/insights/api/config/notifications/BossBarNotification.java
@@ -41,7 +41,7 @@ public class BossBarNotification implements Notification {
 
     @Override
     public BossBarNotification add(Player player) {
-        receivers.add(plugin.getMessages().getAudiences().player(player));
+        receivers.add(player);
         return this;
     }
 

--- a/Insights-Core/src/main/java/dev/frankheijden/insights/Insights.java
+++ b/Insights-Core/src/main/java/dev/frankheijden/insights/Insights.java
@@ -44,7 +44,6 @@ import dev.frankheijden.insights.placeholders.InsightsPlaceholderExpansion;
 import dev.frankheijden.insights.tasks.PlayerTrackerTask;
 import io.leangen.geantyref.TypeToken;
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
-import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
@@ -86,7 +85,6 @@ public class Insights extends InsightsPlugin {
     private InsightsPlaceholderExpansion placeholderExpansion;
     private ScheduledTask playerTracker = null;
     private ScheduledTask updateChecker = null;
-    private BukkitAudiences audiences = null;
     private RedstoneUpdateCount redstoneUpdateCount = null;
     private ChunkTeleport chunkTeleport;
     private InsightsNMS nms;
@@ -107,7 +105,6 @@ public class Insights extends InsightsPlugin {
         }
         nms = InsightsNMS.get();
 
-        this.audiences = BukkitAudiences.create(this);
         this.listenerManager = new ListenerManager(this);
         reloadConfigs();
 
@@ -164,7 +161,6 @@ public class Insights extends InsightsPlugin {
             placeholderExpansion = null;
         }
         chunkContainerExecutor.shutdown();
-        audiences.close();
     }
 
     @Override
@@ -201,7 +197,7 @@ public class Insights extends InsightsPlugin {
     public void reloadMessages() {
         File file = new File(getDataFolder(), MESSAGES_FILE_NAME);
         try {
-            messages = Messages.load(this, this.audiences, file, getResource(MESSAGES_FILE_NAME));
+            messages = Messages.load(this, file, getResource(MESSAGES_FILE_NAME));
         } catch (IOException ex) {
             ex.printStackTrace();
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,9 +57,6 @@ subprojects {
     dependencies {
         compileOnly(libs.paperApi)
         implementation(libs.bStatsBukkit)
-        implementation(libs.adventureApi)
-        implementation(libs.adventureMiniMessage)
-        implementation(libs.adventurePlatformBukkit)
 
         if (!nms || nmsImpl) {
             compileOnly(project(":Insights-NMS-Core"))
@@ -109,9 +106,6 @@ subprojects {
     tasks.withType<ShadowJar> {
         relocate("dev.frankheijden.minecraftreflection", "$dependencyDir.minecraftreflection")
         relocate("org.bstats", "$dependencyDir.bstats")
-        relocate("net.kyori.adventure", "$dependencyDir.adventure")
-        relocate("net.kyori.examination", "$dependencyDir.examination")
-        relocate("net.kyori.option", "$dependencyDir.option")
         if (nmsImpl) {
             relocate(project.group.toString().replaceAfterLast('.', "impl"), project.group.toString())
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 semver = "0.10.2"
 minecraft = "26.2.build.+"
 bStats = "3.0.0"
-adventure = "4.17.0"
-adventurePlatformBukkit = "4.4.1"
+# adventure = "4.17.0"
+# adventurePlatformBukkit = "4.4.1"
 assertj = "3.23.1"
 mockito = "4.11.0"
 jupiter = "5.9.1"
@@ -26,9 +26,9 @@ pluginYml = "0.6.0"
 semver = { group = "com.github.zafarkhaja", name = "java-semver", version.ref = "semver" }
 paperApi = { group = "io.papermc.paper", name = "paper-api", version.ref = "minecraft" }
 bStatsBukkit = { group = "org.bstats", name = "bstats-bukkit", version.ref = "bStats" }
-adventureApi = { group = "net.kyori", name = "adventure-api", version.ref = "adventure" }
-adventureMiniMessage = { group = "net.kyori", name = "adventure-text-minimessage", version.ref = "adventure" }
-adventurePlatformBukkit = { group = "net.kyori", name = "adventure-platform-bukkit", version.ref = "adventurePlatformBukkit" }
+#adventureApi = { group = "net.kyori", name = "adventure-api", version.ref = "adventure" }
+# adventureMiniMessage = { group = "net.kyori", name = "adventure-text-minimessage", version.ref = "adventure" }
+# adventurePlatformBukkit = { group = "net.kyori", name = "adventure-platform-bukkit", version.ref = "adventurePlatformBukkit" }
 assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 mockitoCore = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 jupiterApi = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "jupiter" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,6 @@
 semver = "0.10.2"
 minecraft = "26.2.build.+"
 bStats = "3.0.0"
-# adventure = "4.17.0"
-# adventurePlatformBukkit = "4.4.1"
 assertj = "3.23.1"
 mockito = "4.11.0"
 jupiter = "5.9.1"
@@ -26,9 +24,6 @@ pluginYml = "0.6.0"
 semver = { group = "com.github.zafarkhaja", name = "java-semver", version.ref = "semver" }
 paperApi = { group = "io.papermc.paper", name = "paper-api", version.ref = "minecraft" }
 bStatsBukkit = { group = "org.bstats", name = "bstats-bukkit", version.ref = "bStats" }
-#adventureApi = { group = "net.kyori", name = "adventure-api", version.ref = "adventure" }
-# adventureMiniMessage = { group = "net.kyori", name = "adventure-text-minimessage", version.ref = "adventure" }
-# adventurePlatformBukkit = { group = "net.kyori", name = "adventure-platform-bukkit", version.ref = "adventurePlatformBukkit" }
 assertj = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 mockitoCore = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 jupiterApi = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "jupiter" }


### PR DESCRIPTION
This fixes the Adventure support on version 26.2.

- Remove the Adventure dependency to use the one provided by Paper
- Exclude air from item hover events (Item must be non-empty)